### PR TITLE
Removed model_type key.

### DIFF
--- a/MoCap/utils.py
+++ b/MoCap/utils.py
@@ -132,7 +132,7 @@ def amass_fk(npz_data_path, bm_path):
         comp_device = torch.device("cuda")
     else:
         comp_device = torch.device("cpu")
-    bm = BodyModel(bm_path=bm_path, model_type="smplh", batch_size=1, num_betas=10).to(
+    bm = BodyModel(bm_path=bm_path, batch_size=1, num_betas=10).to(
         comp_device
     )
     bdata = np.load(npz_data_path)


### PR DESCRIPTION
Fixed error:

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-11-cee14851a8b1> in <module>
      2 bm_path = '/home/ugnelis/GIT/MoVi/chark/amass/body_models/smplh/male/model.npz'
      3 
----> 4 joints, verts = amass_fk(npz_bdata_path, bm_path)
      5 print('Shape of joints tensor: ', joints.shape)
      6 print('Shape of verts tensor: ', verts.shape)

~/GIT/MoVi/chark/MoVi-Toolbox/MoCap/utils.py in amass_fk(npz_data_path, bm_path)
    133     else:
    134         comp_device = torch.device("cpu")
--> 135     bm = BodyModel(bm_path=bm_path, model_type="smplh", batch_size=1, num_betas=10).to(
    136         comp_device
    137     )

TypeError: __init__() got an unexpected keyword argument 'model_type'
```
The bug was in `utils.py`. This files was sending flag `model_type="smplh"` via `BodyModel` but the `BodyModel` wasn't expecting (https://github.com/nghorbani/human_body_prior/blob/master/human_body_prior/body_model/body_model.py#L35). The model type itself is defined automatically without passing a flag. 